### PR TITLE
Added support for non-int seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For Example:
 const SeededRandomSequence = preload("res://lib/SeededRandomSequence.gd")
 
 #Variables for the seed and RNG
-export(int) var seed = 0
+export(String) var seed = 0
 var _rng
 
 func _ready():

--- a/SeededRandomSequence.gd
+++ b/SeededRandomSequence.gd
@@ -31,9 +31,12 @@ func reset(new_seed=null):
 		#Set that seed
 		self._initial_seed = new_seed
 	
+	#Hash the seed to support non-integers
+	var hashed_seed = hash(self._initial_seed)
+	
 	#Get the first state
 	self._result_sequence = []
-	self._current_state = rand_seed(hash(self._initial_seed))[1]
+	self._current_state = rand_seed(hashed_seed)[1]
 
 #Get the next number
 func next():

--- a/SeededRandomSequence.gd
+++ b/SeededRandomSequence.gd
@@ -33,7 +33,7 @@ func reset(new_seed=null):
 	
 	#Get the first state
 	self._result_sequence = []
-	self._current_state = rand_seed(self._initial_seed)[1]
+	self._current_state = rand_seed(hash(self._initial_seed))[1]
 
 #Get the next number
 func next():


### PR DESCRIPTION
I was hoping to be able to do a RimWorld type thing where I type in a funny phrase and see what kinda scenario pops out, but this asset won't allow that kind of thing. Just a quick fix needed. Will work with any data type honestly since `@GDScript.hash(Variant)` supports converting ANY data type into an int to seed with.